### PR TITLE
Fix/size and escapes

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ Make sure to surround each graphic with a ``begin`` and ``end`` block of the adj
   \end{adjustbox}
   Text following the graphic
   ```
+A JSON example would look as follows:
+```json
+{"content":"Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, \n\n\n\\begin{adjustbox}{max width=\textwidth}\n\\begin{quantikz}[row sep=0.1cm]& \\gate{X} & \\ctrl{1} & \\gate{X} & \\qw \\\\&  \\gate{X} & \\ctrl{1} & \\gate{X} & \\qw \\\\& \\gate{X} & \\ctrl{1} & \\gate{X} & \\qw \\\\& \\gate{X} & \\ctrl{1} & \\gate{X} & \\qw \\\\& \\gate{X} & \\ctrl{1} & \\gate{X} & \\qw \\\\& \\gate{X} & \\ctrl{1} & \\gate{X} & \\qw \\\\& \\gate{X} & \\ctrl{1} & \\gate{X} & \\qw \\\\& \\gate{X} & \\ctrl{1} & \\gate{X} & \\qw \\\\& \\gate{X} & \\ctrl{1} & \\gate{X} & \\qw \\\\& \\gate{X} & \\ctrl{1} & \\gate{X} & \\qw \\\\& \\gate{X} & \\ctrl{1} & \\gate{X} & \\qw \\\\& \\gate{X} & \\ctrl{1} & \\gate{X} & \\qw \\\\& \\qw & \\control{} & \\qw & \\qw \\\\& \\gate{X} & \\qw & \\qw & \\qw \\\\& \\gate{H} & \\qw & \\qw & \\qw\\end{quantikz}\n\\end{adjustbox}\n\n\n Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren,  ","latexPackages":["\\usepackage{tikz}","\\usetikzlibrary{quantikz}","\\usepackage{adjustbox}"],"output":"svg", "varwidth":1.2 }
+```
 
 ### Notes:
 * LatexRenderer creates a new latex document with the following structure:

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ It is possible to request the data with either a POST- or a GET-Request
 
 **Optional** attributes: 
 * *packages* (default: None, type: List<String>): List of packages that is required for rendering the content 
-* output (default: "svg", type: String): Rendering output format, according to description above
-* varwidth (default: None, type: Number/Float): When rendering text it is recommended to set varwidth. Varwidth manages the linebreaks for the standalone package which is used for all output types but "fullpdf". 
+* *output* (default: "svg", type: String): Rendering output format, according to description above
+* *varwidth* (default: None, type: Number/Float): When rendering text it is recommended to set varwidth. Varwidth manages the linebreaks for the standalone package which is used for all output types but "fullpdf". 
 Further varwidth guarantees a maximum document width of varwidth\textwidth, meaning a value of 1 will render the documentcontent on a DINA4 page.
 
 ### Userguide:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The latest version is: **1.1.0**
 
 ### Installation:
 * As a **Docker Container** (highly recommended)
-	1. Pull and Run image via: ``docker run --rm -p 8082:8082 planqk/latex-renderer:latest``
+	1. Pull and Run image via: ``docker run --rm -p 5030:5030 planqk/latex-renderer:latest``
 
 * As a **Spring-Boot** project:
 
@@ -20,11 +20,11 @@ The latest version is: **1.1.0**
 	4. To start Latex-Renderer run: ``mvn spring-boot:run``
 
 ### API:
-Runs on Port 8082.
+Runs on Port 5030.
 
 It is possible to request the data with either a POST- or a GET-Request
-* POST: http://localhost:8082/renderLatex  expects (String content, List<String> latexPackages, String output) as [JSON](https://www.json.org/json-en.html)
-* GET: http://localhost:8082/renderLatex expects (String content, List<String> latexPackages, String output) must be [URLEncoded](http://www.eso.org/~ndelmott/url_encode.html)
+* POST: http://localhost:5030/renderLatex  expects (String content, List<String> latexPackages, String output) as [JSON](https://www.json.org/json-en.html)
+* GET: http://localhost:5030/renderLatex expects (String content, List<String> latexPackages, String output) must be [URLEncoded](http://www.eso.org/~ndelmott/url_encode.html)
 
 **Output formats** are:
 * svg (default): returns a SVG that contains the cutout of the rendered content.
@@ -51,14 +51,14 @@ Further varwidth guarantees a maximum document width of varwidth\textwidth, mean
 
 
 #### Examples:
-A minimal GET-Request example to render *pi* without defining any packages or an ouput format: ``http://localhost:8082/renderLatex?content=$%5Cpi$``
+A minimal GET-Request example to render *pi* without defining any packages or an ouput format: ``http://localhost:5030/renderLatex?content=$%5Cpi$``
 
 A POST-Request example that sets the output format to *pdf*, includes the two necessary packages *\usepackage{tikz} and \usetikzlibrary{quantikz}* and sets the content to render a small Quantum Circuit example:
 ```json
 {"content":"\\begin{quantikz} \\lstick{\\ket{0}} & \\phase{\\alpha} & \\gate{H} & \\phase{\\beta} & \\gate{H} & \\phase{\\gamma} & \\rstick{Arbitrary\\\\pure state}\\qw \\end{quantikz}","latexPackages":["\\usepackage{tikz}","\\usetikzlibrary{quantikz}"],"output":"pdf"}
 ```
 The same example as before just sent via a GET-Request:
-``http://localhost:8082/renderLatex?packages=%5Cusepackage%7Btikz%7D&packages=%5Cusetikzlibrary%7Bquantikz%7D&output=pdf&content=%5Cbegin%7Bquantikz%7D+%5Clstick%7B%5Cket%7B0%7D%7D+%26+%5Cphase%7B%5Calpha%7D+%26+%5Cgate%7BH%7D+%26+%5Cphase%7B%5Cbeta%7D+%26+%5Cgate%7BH%7D+%26+%5Cphase%7B%5Cgamma%7D+%26+%5Crstick%7BArbitrary%5C%5Cpure+state%7D%5Cqw+%5Cend%7Bquantikz%7D
+``http://localhost:5030/renderLatex?packages=%5Cusepackage%7Btikz%7D&packages=%5Cusetikzlibrary%7Bquantikz%7D&output=pdf&content=%5Cbegin%7Bquantikz%7D+%5Clstick%7B%5Cket%7B0%7D%7D+%26+%5Cphase%7B%5Calpha%7D+%26+%5Cgate%7BH%7D+%26+%5Cphase%7B%5Cbeta%7D+%26+%5Cgate%7BH%7D+%26+%5Cphase%7B%5Cgamma%7D+%26+%5Crstick%7BArbitrary%5C%5Cpure+state%7D%5Cqw+%5Cend%7Bquantikz%7D
 ``
 
 When rendering pictures and text in one request it is recommended to set varwidth and additionally add ``\usepackage{adjustbox}`` to the package list. 

--- a/README.md
+++ b/README.md
@@ -33,22 +33,14 @@ It is possible to request the data with either a POST- or a GET-Request
 * jpg: returns a JPEG that contains the cutout of the rendered content.
 * fullPdf: returns a PDF document that contains the rendered content on ISO A4 pages.
 
-**Required** attribute: content
+**Required** attributes: 
+* *content* (default: None, type: String): The LaTeX documentcontent that shall be rendered.
 
-**Optional** attributes: packages(default: None), output (default: svg)
-
-#### Examples:
-A minimal GET-Request example to render *pi* without defining any packages or an ouput format: ``http://localhost:8082/renderLatex?content=$%5Cpi$``
-
-A POST-Request example that sets the output format to *pdf*, includes the two necessary packages *\usepackage{tikz} and \usetikzlibrary{quantikz}* and sets the content to render a small Quantum Circuit example:
-```json
-{"content":"\\begin{quantikz} \\lstick{\\ket{0}} & \\phase{\\alpha} & \\gate{H} & \\phase{\\beta} & \\gate{H} & \\phase{\\gamma} & \\rstick{Arbitrary\\\\pure state}\\qw \\end{quantikz}","latexPackages":["\\usepackage{tikz}","\\usetikzlibrary{quantikz}"],"output":"pdf"}``
-```
-The same example as before just sent via a GET-Request:
-``http://localhost:8082/renderLatex?packages=%5Cusepackage%7Btikz%7D&packages=%5Cusetikzlibrary%7Bquantikz%7D&output=pdf&content=%5Cbegin%7Bquantikz%7D+%5Clstick%7B%5Cket%7B0%7D%7D+%26+%5Cphase%7B%5Calpha%7D+%26+%5Cgate%7BH%7D+%26+%5Cphase%7B%5Cbeta%7D+%26+%5Cgate%7BH%7D+%26+%5Cphase%7B%5Cgamma%7D+%26+%5Crstick%7BArbitrary%5C%5Cpure+state%7D%5Cqw+%5Cend%7Bquantikz%7D
-``
-
-
+**Optional** attributes: 
+* *packages* (default: None, type: List<String>): List of packages that is required for rendering the content 
+* output (default: "svg", type: String): Rendering output format, according to description above
+* varwidth (default: None, type: Number/Float): When rendering text it is recommended to set varwidth. Varwidth manages the linebreaks for the standalone package which is used for all output types but "fullpdf". 
+Further varwidth guarantees a maximum document width of varwidth\textwidth, meaning a value of 1 will render the documentcontent on a DINA4 page.
 
 ### Userguide:
 * This service is intended for automated latex rendering.
@@ -58,6 +50,26 @@ The same example as before just sent via a GET-Request:
 * The *content* string should be prepared properly before sending, so the latex compiler won't have any issues because of missing spaces or linebreaks. Follow the instructions in the *Notes* section to make sure your latex string works.
 
 
+#### Examples:
+A minimal GET-Request example to render *pi* without defining any packages or an ouput format: ``http://localhost:8082/renderLatex?content=$%5Cpi$``
+
+A POST-Request example that sets the output format to *pdf*, includes the two necessary packages *\usepackage{tikz} and \usetikzlibrary{quantikz}* and sets the content to render a small Quantum Circuit example:
+```json
+{"content":"\\begin{quantikz} \\lstick{\\ket{0}} & \\phase{\\alpha} & \\gate{H} & \\phase{\\beta} & \\gate{H} & \\phase{\\gamma} & \\rstick{Arbitrary\\\\pure state}\\qw \\end{quantikz}","latexPackages":["\\usepackage{tikz}","\\usetikzlibrary{quantikz}"],"output":"pdf"}
+```
+The same example as before just sent via a GET-Request:
+``http://localhost:8082/renderLatex?packages=%5Cusepackage%7Btikz%7D&packages=%5Cusetikzlibrary%7Bquantikz%7D&output=pdf&content=%5Cbegin%7Bquantikz%7D+%5Clstick%7B%5Cket%7B0%7D%7D+%26+%5Cphase%7B%5Calpha%7D+%26+%5Cgate%7BH%7D+%26+%5Cphase%7B%5Cbeta%7D+%26+%5Cgate%7BH%7D+%26+%5Cphase%7B%5Cgamma%7D+%26+%5Crstick%7BArbitrary%5C%5Cpure+state%7D%5Cqw+%5Cend%7Bquantikz%7D
+``
+
+When rendering pictures and text in one request it is recommended to set varwidth and additionally add ``\usepackage{adjustbox}`` to the package list. 
+Make sure to surround each graphic with a ``begin`` and ``end`` block of the adjustbox environment as follows:
+  ```latex
+  Text before the graphic
+  \begin{adjustbox}{max width=\textwidth}
+    GRAPHIC HERE
+  \end{adjustbox}
+  Text following the graphic
+  ```
 
 ### Notes:
 * LatexRenderer creates a new latex document with the following structure:

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
         <dependency>
             <groupId>org.apache.xmlgraphics</groupId>
             <artifactId>batik-dom</artifactId>
-            <version>1.14</version>
+            <version>1.9</version>
         </dependency>
         <dependency>
             <groupId>org.apache.xmlgraphics</groupId>
@@ -93,12 +93,17 @@
         <dependency>
             <groupId>org.apache.xmlgraphics</groupId>
             <artifactId>batik-svg-dom</artifactId>
-            <version>1.7</version>
+            <version>1.9</version>
         </dependency>
         <dependency>
             <groupId>org.apache.xmlgraphics</groupId>
             <artifactId>batik-svggen</artifactId>
-            <version>1.14</version>
+            <version>1.9</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.xmlgraphics</groupId>
+            <artifactId>batik-bridge</artifactId>
+            <version>1.9</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/com/renderLatex/entities/LatexContent.java
+++ b/src/main/java/com/renderLatex/entities/LatexContent.java
@@ -19,10 +19,18 @@ public class LatexContent {
     private MediaType contentType;
     private byte[] returnFile;
     private String filepath;
+    private float varwidth = -1;
 
     public LatexContent(String content, List<String> latexPackages,String output){
         this.content = content;
         this.latexPackages = latexPackages;
         this.output = output;
+    }
+
+    public LatexContent(String content, List<String> latexPackages,String output, float varwidth){
+        this.content = content;
+        this.latexPackages = latexPackages;
+        this.output = output;
+        this.varwidth = varwidth;
     }
 }

--- a/src/main/java/com/renderLatex/rest/RenderLatexController.java
+++ b/src/main/java/com/renderLatex/rest/RenderLatexController.java
@@ -64,7 +64,10 @@ public class RenderLatexController {
     @GetMapping(
             value = "/renderLatex"
     )
-    public ResponseEntity<byte[]> renderLatexGet(@RequestParam(value = "packages", required = false) List<String> packages, @RequestParam("content") String content, @RequestParam(value = "output", required = false) String output) {
+    public ResponseEntity<byte[]> renderLatexGet(@RequestParam(value = "packages", required = false) List<String> packages,
+                                                 @RequestParam("content") String content,
+                                                 @RequestParam(value = "output", required = false) String output,
+                                                 @RequestParam(value = "varwidth", required = false) Float varwidth) {
         try {
             if (output == null){
                 output = "svg";
@@ -76,12 +79,16 @@ public class RenderLatexController {
                 packages.set(i, java.net.URLDecoder.decode(packages.get(i), StandardCharsets.UTF_8.name()));
             }
             content = java.net.URLDecoder.decode(content, StandardCharsets.UTF_8.name());
+
+            if (varwidth == null ){
+                varwidth = -1.0f;
+            }
         } catch (UnsupportedEncodingException e) {
             // Could not Decode URL
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(null);
         }
 
-        LatexContent latexContent= new LatexContent(content, packages, output);
+        LatexContent latexContent= new LatexContent(content, packages, output, varwidth);
         try{
             latexContent = handleContentRendering(latexContent);
             HttpHeaders headers = new HttpHeaders();

--- a/src/main/java/com/renderLatex/service/RenderService.java
+++ b/src/main/java/com/renderLatex/service/RenderService.java
@@ -2,9 +2,13 @@ package com.renderLatex.service;
 
 import com.renderLatex.entities.LatexContent;
 import com.renderLatex.utils.Utils;
+import org.apache.batik.anim.dom.SAXSVGDocumentFactory;
+import org.apache.batik.bridge.*;
 import org.apache.batik.dom.GenericDOMImplementation;
+import org.apache.batik.gvt.GraphicsNode;
 import org.apache.batik.svggen.SVGGeneratorContext;
 import org.apache.batik.svggen.SVGGraphics2D;
+import org.apache.batik.util.XMLResourceDescriptor;
 import org.apache.commons.io.FileUtils;
 import org.apache.pdfbox.Loader;
 import org.apache.pdfbox.pdmodel.PDDocument;
@@ -15,6 +19,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.w3c.dom.DOMImplementation;
 import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.svg.SVGDocument;
 
 import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
@@ -27,7 +33,8 @@ import java.util.Locale;
 
 @Service
 public class RenderService {
-    private String latexDocClass = "\\documentclass{standalone} \n";
+    // TODO varwidth should be optional parameter?
+    private String latexDocClass = "\\documentclass[margin=7pt, varwidth]{standalone} \n";
     private final String docStart = "\\begin{document} \n";
     private final String docEnd = " \\end{document} \n";
     private final String tempDirectory = Utils.concatPaths("", "tmp");
@@ -49,8 +56,9 @@ public class RenderService {
     public String render(LatexContent latexContent){
         //create new Folder for renderingProcess and get its Path
         final String currentRenderPath = Utils.createPathWithUUID(tempDirectory);
-        final String content = latexContent.getContent();
-        final String packages = String.join(" ", latexContent.getLatexPackages());
+        String content = latexContent.getContent();
+        content = content.replaceAll("(\\t(?!([^\\w]| )))","\\\\t");
+        String packages = String.join(" ", latexContent.getLatexPackages());
 
         String output = latexContent.getOutput();
         if (output.equals("fullPdf")) {
@@ -144,6 +152,29 @@ public class RenderService {
 
                 page.print(svgGenerator, format, i);
                 svgGenerator.stream(svgFName);
+
+                SAXSVGDocumentFactory factory = new SAXSVGDocumentFactory(
+                        XMLResourceDescriptor.getXMLParserClassName());
+
+                File file = new File(svgFName);
+                InputStream is = new FileInputStream(file);
+
+                Document document2 = factory.createDocument(
+                        file.toURI().toURL().toString(), is);
+                UserAgent agent = new UserAgentAdapter();
+                DocumentLoader loader= new DocumentLoader(agent);
+                BridgeContext context = new BridgeContext(agent, loader);
+                context.setDynamic(true);
+                GVTBuilder builder= new GVTBuilder();
+                GraphicsNode root= builder.build(context, document2);
+
+                Element svgRoot = document2.getDocumentElement();
+                double width = root.getPrimitiveBounds().getWidth();
+                double height = root.getPrimitiveBounds().getHeight();
+                svgRoot.setAttributeNS(null, "width", String.valueOf(width*2.25));
+                svgRoot.setAttributeNS(null, "height", String.valueOf(height*2.25));
+                svgRoot.setAttributeNS(null, "viewBox", "0 0 " + String.valueOf(width) + " " + String.valueOf(height));
+                saveSvgDocumentToFile((SVGDocument) document2, file);
             }
         } catch (IOException | PrinterException e) {
             e.printStackTrace();
@@ -165,6 +196,14 @@ public class RenderService {
                 }
             } catch (IOException e) {
             e.printStackTrace();
+        }
+    }
+
+    public static void saveSvgDocumentToFile(SVGDocument document, File file)
+            throws FileNotFoundException, IOException {
+        SVGGraphics2D svgGenerator = new SVGGraphics2D(document);
+        try (Writer out = new OutputStreamWriter(new FileOutputStream(file), "UTF-8")) {
+            svgGenerator.stream(document.getDocumentElement(), out);
         }
     }
 }

--- a/src/main/java/com/renderLatex/utils/Utils.java
+++ b/src/main/java/com/renderLatex/utils/Utils.java
@@ -4,6 +4,8 @@ import org.apache.commons.io.FileUtils;
 
 import java.io.File;
 import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.nio.file.Paths;
 import java.util.UUID;
 
@@ -31,5 +33,9 @@ public class Utils {
             System.out.println("directory created");
         }
         return uuidPath;
+    }
+
+    public static float roundFloat(float d, int decimalPlace) {
+        return BigDecimal.valueOf(d).setScale(decimalPlace, RoundingMode.HALF_UP).floatValue();
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,2 @@
 server.port=5030
-springdoc.api-docs.path=/api-docs
+springdoc.api-docs.path=/v3/api-docs

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,2 @@
-server.port=8082
+server.port=5030
 springdoc.api-docs.path=/api-docs


### PR DESCRIPTION
Increasing the size by factor 2.25

Enabling linebreak in standalone mode

Adjusting docs

Test in combination with: https://github.com/UST-QuAntiL/qc-atlas-ui/tree/fix/tex-rendering-lb

closes https://github.com/UST-QuAntiL/latex-renderer/issues/9